### PR TITLE
Add basic support for cleveref

### DIFF
--- a/lib/reference-provider.coffee
+++ b/lib/reference-provider.coffee
@@ -14,6 +14,10 @@ class ReferenceProvider
     "nameref"
     "vref"
     "eqref"
+    "cref"
+    "cpageref"
+    "Cref"
+    "Cpageref"
   ]
 
 

--- a/spec/reference-provider-spec.coffee
+++ b/spec/reference-provider-spec.coffee
@@ -77,3 +77,19 @@ describe "Latex Referemces Autocompletions", ->
   it "has has only equations for eqref", ->
     editor.setText('\\eqref{s')
     checkSuggestion('eq:section')
+
+  it "has completions for the cref command", ->
+    editor.setText('\\cref{fig:fi')
+    checkSuggestion()
+
+  it "has completions for the cpageref command", ->
+    editor.setText('\\cpageref{fig:fi')
+    checkSuggestion()
+
+  it "has completions for the Cref command", ->
+    editor.setText('\\Cref{fig:fi')
+    checkSuggestion()
+
+  it "has completions for the Cpageref command", ->
+    editor.setText('\\Cpageref{fig:fi')
+    checkSuggestion()


### PR DESCRIPTION
This PR supports the [`cleveref`][cleveref-ctan] package to some degree.

![autocompletion](https://user-images.githubusercontent.com/13291527/33869056-241ecef4-df4a-11e7-97a1-0289c6b0b1fc.png)

This does not support the following feature of the package. 

- comma-separated labels in the argument of `\cref`
- `\crefrange`, which accepts two arguments as labels

How to support these is not so self-evident with the current implementation. That's why I only added some command names to `refCommandList` instead of a more drastic change that supports all the functionality provided by `cleveref`.

P.S. I really like your idea of displaying the contents of caption or section. :+1:

[cleveref-ctan]: https://ctan.org/pkg/cleveref