### PR TITLE
Add keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "language-latex:grammar-used",
     "language-latex2e:grammar-used"
   ],
-  "keywords": [],
+  "keywords": [
+    "latex",
+    "autocomplete"
+  ],
   "repository": "https://github.com/hesstobi/atom-autocomplete-latex-references.git",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Adds keywords to the `package.json` file, which should help visibility in a package search engine. I'm not sure if it's necessary, given the words are in the package name, but it doesn't hurt.